### PR TITLE
feat(helpers:pinGitHubActionDigests): pin tag to commit hash

### DIFF
--- a/default.json
+++ b/default.json
@@ -22,7 +22,7 @@
       "matchDepTypes": [
         "action"
       ],
-      "groupName": "pintagtodigest",
+      "groupName": "github action tag version to digest",
       "groupSlug": "pintagtodigest",
       "pinDigests": true,
       "schedule": [ "* */6 * * *" ]

--- a/default.json
+++ b/default.json
@@ -25,7 +25,7 @@
       "groupName": "pintagtodigest",
       "groupSlug": "pintagtodigest",
       "pinDigests": true,
-      "schedule": [ "0 */6 * * *" ]
+      "schedule": [ "* */6 * * *" ]
     },
     {
       "matchManagers": ["npm"],

--- a/default.json
+++ b/default.json
@@ -19,6 +19,15 @@
   ],
   "packageRules": [
     {
+      "matchDepTypes": [
+        "action"
+      ],
+      "groupName": "pintagtodigest",
+      "groupSlug": "pintagtodigest",
+      "pinDigests": true,
+      "schedule": [ "0 */6 * * *" ]
+    },
+    {
       "matchManagers": ["npm"],
       "matchPackageNames": ["cesium"],
       "groupName": "cesium",


### PR DESCRIPTION
## Description

Add [pinGitHubActionDigests](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests) to schedule auto pinning tag version to commit-hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Reference
- https://docs.renovatebot.com/configuration-options/#pindigests

> If enabled Renovate will pin Docker images or GitHub Actions by means of their SHA256 digest and not only by tag so that they are immutable.

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to group and pin digests for "action" type dependencies, with updates scheduled every 6 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->