### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: renovate-config
+  namespace: reearth
+  description: Sharable config preset for Renovate used in Re:Earth
+  annotations:
+    github.com/project-slug: reearth/renovate-config
+  links:
+  - url: https://github.com/reearth/renovate-config
+    title: GitHub
+    icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/sre


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `renovate-config` (namespace `reearth`)
- **Owner:** `reearth/sre`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.